### PR TITLE
Fix build failures from a clean checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.tar.gz
 *.pyc
 web/*.pyc
+bin

--- a/Makefile
+++ b/Makefile
@@ -48,12 +48,13 @@ bin/mcp55: mcp55.o sph/md4.o
 bin/mcp56: mcp56.o
 
 bin/%:
+	mkdir bin || true
 	$(CC) -o $@ $^ $(CFLAGS) $(LDFLAGS)
-	
+
 clean:
 	$(RM) $(TARGETS) *.o *.pyc web/*.pyc web/*/*.pyc
 
-test:
+test: $(TARGETS)
 	./run-tests-1.sh
 	./run-tests-2.sh
 	./run-tests-3.sh

--- a/mcp19.c
+++ b/mcp19.c
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
 
   for (size_t i = 0; i < GUESSLEN; i++)
   {
-    uint8_t best;
+    uint8_t best = 0u;
     int best_score = 0xffff;
 
     for (int guess = 0; guess < 256; guess++)


### PR DESCRIPTION
The compilation recipe expects the presence of a `bin` directory to
emit the output binary. That directory does not exist in a clean
checkout of the repository, causing the link recipe to fail. Fix that
recipe to make that directory if it doesn't already exist.

~~GCC 6.2.0 emits warnings due to the unknown `%z` format specifier in
`printf` calls. Remove the `-Werror` compiler option to prevent the
build from failing due to this.~~

Also ignore the build products in the `bin` directory in `.gitignore`.

The `Makefile` allows the `test` target rule to run parallel to the
`$(TARGETS)` rule (especially when recipe parallelization is enabled),
which results in several test failures due to the programs not yet
linked. Fix this by enlisting `$(TARGETS)` as a prerequisite of `test`.

Finally, fix a minor warning in `mcp19` due to GCC thinking a variable
gets used without initialization. While GCC is incorrect here, the
warning does cause the build to fail.
